### PR TITLE
no_std fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 cfg-if = "1"
-hex = { version = ">=0.4.2", optional = true }
+hex = { version = ">=0.4.2", optional = true, default-features = false, features = ["alloc"] }
 serde = { version = "1.0", optional = true, default-features = false }
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]


### PR DESCRIPTION
I ran into an issue trying to use this crate in a `no_std` build - without the change here, the `hex` crate brings in `std` due to its default features.