### PR TITLE
Derive Eq trait for FromHexError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 /// The error type for decoding a hex string into `Vec<u8>` or `[u8; N]`.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::module_name_repetitions)]
 pub enum FromHexError {
     /// An invalid character was found. Valid ones are: `0...9`, `a...f`


### PR DESCRIPTION
Without this we cannot derive Eq on enums & structs that contain a FromHexError. It is trivial to derive since all the elements of FromHexError implement Eq already. From reading the [docs](https://doc.rust-lang.org/std/cmp/trait.Eq.html) I think that this type should implement Eq;

> Implement `Eq` in addition to `PartialEq` if it’s guaranteed that `PartialEq::eq(a, a)` always returns true (reflexivity), in addition to the symmetric and transitive properties already required by `PartialEq`

I'm not sure if you've already considered this and rejected it but if not, including this would save me some hassle.