### PR TITLE
implement is_zeroes for checking all-zero hex strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -627,6 +627,40 @@ unsafe fn decode_checked(input: &[u8], output: &mut [u8]) -> Result<(), FromHexE
     Err(unsafe { invalid_hex_error(input) })
 }
 
+/// Checks if a hex string contains only zeros ('0' characters).
+///
+/// Both uppercase and lowercase hex strings are supported, and can be mixed.
+/// The '0x' prefix is automatically stripped if present.
+///
+/// Returns true only if the entire string (after removing any '0x' prefix)
+/// consists of '0' characters. Returns false if any non-zero hex digit is found.
+///
+/// # Example
+///
+/// ```
+/// assert!(const_hex::is_zeroes("000000"));
+/// assert!(const_hex::is_zeroes("0x000000"));
+///
+/// assert!(!const_hex::is_zeroes("100000"));
+/// assert!(!const_hex::is_zeroes("0x100000"));
+/// assert!(!const_hex::is_zeroes("000100"));
+/// assert!(!const_hex::is_zeroes(""));
+/// ```
+#[cfg(feature = "alloc")]
+#[inline]
+pub fn is_zeroes(hex: &str) -> bool {
+    if hex.is_empty() {
+        return false;
+    }
+    let bytes = strip_prefix(hex.as_bytes());
+    for &b in bytes {
+        if b != b'0' {
+            return false;
+        }
+    }
+    true
+}
+
 #[inline]
 const fn byte2hex<const UPPER: bool>(byte: u8) -> (u8, u8) {
     let table = get_chars_table::<UPPER>();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -214,3 +214,22 @@ fn assert_upper(s: &str) {
     assert_eq!(ALL_UPPER, expected);
     assert_eq!(s, expected);
 }
+
+#[cfg(feature = "alloc")]
+#[test]
+fn test_is_zeroes() {
+    // Test with standard zero-only strings
+    assert!(const_hex::is_zeroes("00000000"));
+    assert!(const_hex::is_zeroes("0x00000000"));
+    assert!(const_hex::is_zeroes("00000000000000000000000000000000"));
+    assert!(const_hex::is_zeroes("0x00000000000000000000000000000000"));
+
+    // Test with non-zero hex strings
+    assert!(!const_hex::is_zeroes("00000001"));
+    assert!(!const_hex::is_zeroes("0x00000001"));
+    assert!(!const_hex::is_zeroes("1234567890abcdef"));
+    assert!(!const_hex::is_zeroes("0x1234567890abcdef"));
+
+    // Test with empty string (could be considered as not zeroes)
+    assert!(!const_hex::is_zeroes(""));
+}


### PR DESCRIPTION
This PR introduces `is_zeroes` helper function, which makes it easy to check if a hex string consists entirely of zeroes, with optional support for a "0x" prefix. This function will be helpful in scenarios where we need to verify if a given value is zeroed out, such as in blockchain, cryptographic where null values are often represented as zero-filled hex strings.
